### PR TITLE
Added options to allow domain length and local length overriddible, triggered by facebook proxy mail length

### DIFF
--- a/lib/validates_email_format_of.rb
+++ b/lib/validates_email_format_of.rb
@@ -30,7 +30,7 @@ module ValidatesEmailFormatOf
                           :with => ValidatesEmailFormatOf::Regex ,
                           :domain_length=>255,
                           :local_length=>64
-                          :}
+                          }
       options.merge!(default_options) {|key, old, new| old}  # merge the default options into the specified options, retaining all specified options
 
       email.strip!


### PR DESCRIPTION
As title, I came across this problem with facebook email.
