### PR TITLE
Activemodel support

### DIFF
--- a/lib/validates_email_format_of.rb
+++ b/lib/validates_email_format_of.rb
@@ -1,7 +1,9 @@
 # encoding: utf-8
 module ValidatesEmailFormatOf
   require 'resolv'
-  
+
+  MessageScope = defined?(ActiveModel) ? :activemodel : :activerecord
+
   LocalPartSpecialChars = Regexp.escape('!#$%&\'*-/=?+-^_`{|}~')
   LocalPartUnquoted = '([[:alnum:]' + LocalPartSpecialChars + ']+[\.]+)*[[:alnum:]' + LocalPartSpecialChars + '+]+'
   LocalPartQuoted = '\"([[:alnum:]' + LocalPartSpecialChars + '\.]|\\\\[\x00-\xFF])*\"'
@@ -14,7 +16,7 @@ module ValidatesEmailFormatOf
     end
     @mx.size > 0 ? true : false
   end
-  
+
   # Validates whether the specified value is a valid email address.  Returns nil if the value is valid, otherwise returns an array
   # containing one or more validation error messages.
   #
@@ -26,9 +28,9 @@ module ValidatesEmailFormatOf
   # * <tt>local_length</tt> Maximum number of characters allowed in the local part (default is 64)
   # * <tt>domain_length</tt> Maximum number of characters allowed in the domain part (default is 255)
   def self.validate_email_format(email, options={})
-      default_options = { :message => I18n.t(:invalid_email_address, :scope => [:activerecord, :errors, :messages], :default => 'does not appear to be a valid e-mail address'),
+      default_options = { :message => I18n.t(:invalid_email_address, :scope => [MessageScope, :errors, :messages], :default => 'does not appear to be a valid e-mail address'),
                           :check_mx => false,
-                          :mx_message => I18n.t(:email_address_not_routable, :scope => [:activerecord, :errors, :messages], :default => 'is not routable'),
+                          :mx_message => I18n.t(:email_address_not_routable, :scope => [MessageScope, :errors, :messages], :default => 'is not routable'),
                           :with => ValidatesEmailFormatOf::Regex ,
                           :domain_length => 255,
                           :local_length => 64
@@ -48,49 +50,55 @@ module ValidatesEmailFormatOf
       unless email =~ options[:with] and not email =~ /\.\./ and domain.length <= options[:domain_length] and local.length <= options[:local_length]
         return [ options[:message] ]
       end
-      
+
       if options[:check_mx] and !ValidatesEmailFormatOf::validate_email_domain(email)
         return [ options[:mx_message] ]
       end
-      
+
       return nil    # represents no validation errors
+  end
+
+  module Validations
+    # Validates whether the value of the specified attribute is a valid email address
+    #
+    #   class User < ActiveRecord::Base
+    #     validates_email_format_of :email, :on => :create
+    #   end
+    #
+    # Configuration options:
+    # * <tt>message</tt> - A custom error message (default is: "does not appear to be a valid e-mail address")
+    # * <tt>on</tt> - Specifies when this validation is active (default is :save, other options :create, :update)
+    # * <tt>allow_nil</tt> - Allow nil values (default is false)
+    # * <tt>allow_blank</tt> - Allow blank values (default is false)
+    # * <tt>check_mx</tt> - Check for MX records (default is false)
+    # * <tt>mx_message</tt> - A custom error message when an MX record validation fails (default is: "is not routable.")
+    # * <tt>if</tt> - Specifies a method, proc or string to call to determine if the validation should
+    #   occur (e.g. :if => :allow_validation, or :if => Proc.new { |user| user.signup_step > 2 }).  The
+    #   method, proc or string should return or evaluate to a true or false value.
+    # * <tt>unless</tt> - See <tt>:if</tt>
+    def validates_email_format_of(*attr_names)
+      options = { :on => :save,
+        :allow_nil => false,
+        :allow_blank => false }
+      options.update(attr_names.pop) if attr_names.last.is_a?(Hash)
+
+      validates_each(attr_names, options) do |record, attr_name, value|
+        v = value.to_s
+        errors = ValidatesEmailFormatOf::validate_email_format(v, options)
+        errors.each do |error|
+          record.errors.add(attr_name, error)
+        end unless errors.nil?
+      end
+    end
   end
 end
 
-module ActiveRecord
-  module Validations
-    module ClassMethods
-      # Validates whether the value of the specified attribute is a valid email address
-      #
-      #   class User < ActiveRecord::Base
-      #     validates_email_format_of :email, :on => :create
-      #   end
-      #
-      # Configuration options:
-      # * <tt>message</tt> - A custom error message (default is: "does not appear to be a valid e-mail address")
-      # * <tt>on</tt> - Specifies when this validation is active (default is :save, other options :create, :update)
-      # * <tt>allow_nil</tt> - Allow nil values (default is false)
-      # * <tt>allow_blank</tt> - Allow blank values (default is false)
-      # * <tt>check_mx</tt> - Check for MX records (default is false)
-      # * <tt>mx_message</tt> - A custom error message when an MX record validation fails (default is: "is not routable.")
-      # * <tt>if</tt> - Specifies a method, proc or string to call to determine if the validation should
-      #   occur (e.g. :if => :allow_validation, or :if => Proc.new { |user| user.signup_step > 2 }).  The
-      #   method, proc or string should return or evaluate to a true or false value.
-      # * <tt>unless</tt> - See <tt>:if</tt>
-      def validates_email_format_of(*attr_names)
-        options = { :on => :save, 
-                    :allow_nil => false,
-                    :allow_blank => false }
-        options.update(attr_names.pop) if attr_names.last.is_a?(Hash)
-
-        validates_each(attr_names, options) do |record, attr_name, value|
-          v = value.to_s
-          errors = ValidatesEmailFormatOf::validate_email_format(v, options)
-          errors.each do |error|
-            record.errors.add(attr_name, error)
-          end unless errors.nil?
-        end
-      end
-    end   
+if defined?(ActiveModel)
+  module ActiveModel::Validations::HelperMethods
+    include ValidatesEmailFormatOf::Validations
+  end
+else
+  class ActiveRecord::Base
+    extend ValidatesEmailFormatOf::Validations
   end
 end


### PR DESCRIPTION
Sniffs to see if ActiveModel is defined. If so, includes the custom validator
into ActiveModel::Validations::HelperMethods (for Rails 3). If not, extends
ActiveRecord::Base (for Rails 2.x) -- maintaining backwards compatibility.

This allows the custom email validator to be used in environments where
ActiveRecord is not loaded, but that still rely on ActiveModel.
