### PR TITLE
Don't require rake in gemspec

### DIFF
--- a/validates_email_format_of.gemspec
+++ b/validates_email_format_of.gemspec
@@ -1,13 +1,11 @@
-require 'rake'
-
 spec = Gem::Specification.new do |s|
   s.name = 'validates_email_format_of'
   s.version = '1.4.5'
   s.summary = 'Validate e-mail addresses against RFC 2822 and RFC 3696.'
   s.description = s.summary
   s.extra_rdoc_files = ['README.rdoc', 'CHANGELOG.rdoc', 'MIT-LICENSE']
-  s.test_files = FileList['test/**/*.rb', 'test/**/*.yml'].to_a
-  s.files = FileList['MIT-LICENSE', '*.rb', '*.rdoc', 'lib/**/*.rb', 'test/**/*.rb', 'test/**/*.yml'].to_a
+  s.test_files = Dir['test/**/*.rb', 'test/**/*.yml']
+  s.files = Dir['MIT-LICENSE', '*.rb', '*.rdoc', 'lib/**/*.rb', 'test/**/*.rb', 'test/**/*.yml']
   s.require_path = 'lib'
   s.has_rdoc = true
   s.rdoc_options << '--title' <<  'validates_email_format_of'


### PR DESCRIPTION
I couldn't deploy a Rails 3 app with RVM, Bundler and Capistrano until I got rid of `require "rake"` in the gemspec of this plugin. See the commit message for details.

Not sure if it's something weird in my setup or a common issue, but issues aside, since `Dir.[]` seems to work fine, this change should be a slight improvement anyway.
