### PR TITLE
Make 1.5.0 work with ruby 1.8

### DIFF
--- a/lib/validates_email_format_of.rb
+++ b/lib/validates_email_format_of.rb
@@ -92,8 +92,8 @@ module ValidatesEmailFormatOf
         next
       end    
 
-      next if local[i] =~ /[[:alnum:]]/
-      next if local[i] =~ LocalPartSpecialChars
+      next if local[i,1] =~ /[[:alnum:]]/
+      next if local[i,1] =~ LocalPartSpecialChars
       
       # period must be followed by something
       if ord == 46
@@ -120,7 +120,7 @@ module ValidatesEmailFormatOf
         part.nil? or 
         part.empty? or 
         not part =~ /\A[[:alnum:]\-]+\Z/ or
-        part[0] == '-' or part[-1] == '-' # hyphen at beginning or end of part
+        part[0,1] == '-' or part[-1,1] == '-' # hyphen at beginning or end of part
     } 
         
     # ipv4


### PR DESCRIPTION
In ruby 1.8 the string[n] construct returns a character code not a string - to get a string you need to use string[n,1] instead.

With this patch the tests all pass with ruby 1.8.
