### PR TITLE
Fix domain part validation for non alphanumeric characters

### DIFF
--- a/lib/validates_email_format_of.rb
+++ b/lib/validates_email_format_of.rb
@@ -119,7 +119,7 @@ module ValidatesEmailFormatOf
       |part| 
         part.nil? or 
         part.empty? or 
-        not part =~ /\A[[:alnum:]\-]+\Z/ or
+        not part =~ /\A[a-zA-Z0-9\-]+\Z/ or
         part[0,1] == '-' or part[-1,1] == '-' # hyphen at beginning or end of part
     } 
         

--- a/test/validates_email_format_of_test.rb
+++ b/test/validates_email_format_of_test.rb
@@ -97,7 +97,8 @@ class ValidatesEmailFormatOfTest < TEST_CASE
      '@example.com',
      'foo@',
      'foo',
-     'Iñtërnâtiônàlizætiøn@hasnt.happened.to.email'
+     'Iñtërnâtiônàlizætiøn@hasnt.happened.to.email',
+     'foo@Iñtërnâtiônàlizætiøn.example.com'
      ].each do |email|
       assert_invalid(email)
     end


### PR DESCRIPTION
I don't under stood why '[:alnum:]' matching to non alphanumeric characters.
