### PR TITLE
fixed #46.

### DIFF
--- a/lib/validates_email_format_of/rspec_matcher.rb
+++ b/lib/validates_email_format_of/rspec_matcher.rb
@@ -4,9 +4,8 @@ RSpec::Matchers.define :validate_email_format_of do |attribute|
   match do
     actual = subject.is_a?(Class) ? subject.new : subject
     actual.send(:"#{attribute}=", "invalid@example.")
-    expect(actual).to be_invalid
     @expected_message ||= ValidatesEmailFormatOf.default_message
-    expect(actual.errors.messages[attribute.to_sym]).to include(@expected_message)
+    !actual.valid? && actual.errors.messages[attribute.to_sym].include?(@expected_message)
   end
   chain :with_message do |message|
     @expected_message = message


### PR DESCRIPTION
TypeError has occurred in the RSpec Matcher `validate_email_format_of `.

```
Failure/Error: it { should validate_email_format_of(:email) }
TypeError:
    wrong argument type String (expected Module)
```

because it calls `Module#include`.

As is described #46,  I replaced

```ruby
expect(actual).to include(expected_one)
```

by

```ruby
actual.include?(expected_one)
```