### PR TITLE
Suppress warning

### DIFF
--- a/lib/validates_email_format_of.rb
+++ b/lib/validates_email_format_of.rb
@@ -9,7 +9,7 @@ module ValidatesEmailFormatOf
 
   require 'resolv'
 
-  LocalPartSpecialChars = /[\!\#\$\%\&\'\*\-\/\=\?\+\-\^\_\`\{\|\}\~]/
+  LocalPartSpecialChars = /[\!\#\$\%\&\'\*\-\/\=\?\+\^\_\`\{\|\}\~]/
 
   def self.validate_email_domain(email)
     domain = email.to_s.downcase.match(/\@(.+)/)[1]


### PR DESCRIPTION
This PR suppresses the following warning.

```
ruby -v
ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-darwin16]

RUBYOPT=-w bundle exec rspec
/Users/numata/ruby/validates_email_format_of/lib/validates_email_format_of.rb:12: warning: character class has duplicated range: /[\!\#\$\%\&\'\*\-\/\=\?\+\-\^\_\`\{\|\}\~]/
/Users/numata/ruby/validates_email_format_of/lib/validates_email_format_of.rb:110: warning: character class has duplicated range: /[\!\#\$\%\&\'\*\-\/\=\?\+\-\^\_\`\{\|\}\~]/
```