### PR TITLE
Drop now-unused directive from gemspec

### DIFF
--- a/validates_email_format_of.gemspec
+++ b/validates_email_format_of.gemspec
@@ -11,7 +11,6 @@ spec = Gem::Specification.new do |s|
   s.email         = ['code@dunae.ca', 'iybetesh@gmail.com']
   s.homepage      = 'https://github.com/validates-email-format-of/validates_email_format_of'
   s.license       = 'MIT'
-  s.test_files    = s.files.grep(%r{^test/})
   s.files         = `git ls-files`.split($/)
   s.require_paths = ['lib']
 


### PR DESCRIPTION
The test_files directive is no longer used by RubyGems.org.