### PR TITLE
Allow setting check_mx_timeout and reduce the default timeout to 3 seconds

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -40,6 +40,8 @@ Or in your Gemfile:
      String. A custom error message when the email format is invalid (default is: "does not appear to be a valid e-mail address")
   :check_mx
      Boolean. Check domain for a valid MX record (default is false)
+  :check_mx_timeout
+     Integer. Timeout in seconds for checking MX records before a `ResolvTimeout` is raised (default is 3).
   :mx_message
      String. A custom error message when the domain does not match a valid MX record (default is: "is not routable").  Ignored unless :check_mx option is true.
   :local_length

--- a/spec/validates_email_format_of_spec.rb
+++ b/spec/validates_email_format_of_spec.rb
@@ -175,12 +175,14 @@ describe ValidatesEmailFormatOf do
     describe "mx record" do
       domain = "example.com"
       email = "valid@#{domain}"
+      check_mx_timeout = 3
       describe "when testing" do
         let(:dns) { double(Resolv::DNS) }
         let(:mx_record) { [double] }
         let(:a_record) { [double] }
         before(:each) do
           allow(Resolv::DNS).to receive(:open).and_yield(dns)
+          expect(dns).to receive(:"timeouts=").with(3).once
           allow(dns).to receive(:getresources).with(domain, Resolv::DNS::Resource::IN::MX).once.and_return(mx_record)
           allow(dns).to receive(:getresources).with(domain, Resolv::DNS::Resource::IN::A).once.and_return(a_record)
         end


### PR DESCRIPTION
Fixes https://github.com/validates-email-format-of/validates_email_format_of/issues/66