### PR TITLE
Fix rspec run fail when using custom error message

### DIFF
--- a/lib/validates_email_format_of/rspec_matcher.rb
+++ b/lib/validates_email_format_of/rspec_matcher.rb
@@ -6,7 +6,7 @@ RSpec::Matchers.define :validate_email_format_of do |attribute|
     actual.send(:"#{attribute}=", "invalid@example.")
     expect(actual).to be_invalid
     @expected_message ||= ValidatesEmailFormatOf.default_message
-    expect(actual.errors.added?(attribute, :invalid_email_address)).to be_truthy
+    expect(actual.errors.added?(attribute, @expected_message)).to be_truthy
   end
   chain :with_message do |message|
     @expected_message = message


### PR DESCRIPTION
There's a bug appears in spec for `validate_email_format_of` when using custom error message:

```
validates :email,  email_format: { message: "Invalid email format. Please try again." }
```

spec:

```
it { is_expected.to validate_email_format_of(:email).with_message("Invalid email format. Please try again.") }
```

Error:

```
Failure/Error:
it { is_expected.to validate_email_format_of(:email).with_message("Invalid email format. Please try again.") } 
expected #<JobMatcher::Candidate id: nil, email: "invalid@example.", ...> 
to validate email format of :email with message "Invalid email format. Please try again."
```

