### PR TITLE
Enforce i18n >= 0.8.0 in modern Ruby versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 * ⚠️ Deprecate `:with` option - https://github.com/validates-email-format-of/validates_email_format_of/issues/42
+* Require i18n >= 0.8.0 in modern Ruby versions - https://github.com/advisories/GHSA-34hf-g744-jw64
 
 [Unreleased]: https://github.com/validates-email-format-of/validates_email_format_of/compare/v1.7.2...master
 

--- a/validates_email_format_of.gemspec
+++ b/validates_email_format_of.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   if RUBY_VERSION < "1.9.3"
     s.add_dependency "i18n", "< 0.7.0"
   else
-    s.add_dependency "i18n"
+    s.add_dependency "i18n", ">= 0.8.0"
   end
 
   s.add_development_dependency "activemodel"


### PR DESCRIPTION
See https://github.com/advisories/GHSA-34hf-g744-jw64