### PR TITLE
Update spelling: e-mail -> email

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/validates-email-format-of/validates_email_format_of/actions/workflows/ci.yml/badge.svg)]( https://github.com/validates-email-format-of/validates_email_format_of/actions/workflows/ci.yml?query=branch%3Amaster)
 
-A Ruby gem to validate e-mail addresses against RFC 2822 and RFC 5322.
+A Ruby gem to validate email addresses against RFC 2822 and RFC 5322.
 
 ## Why this email validator?
 
@@ -50,14 +50,14 @@ ValidatesEmailFormatOf::load_i18n_locales
 I18n.locale = :pl
 
 ValidatesEmailFormatOf::validate_email_format("example@mydomain.com") # => nil
-ValidatesEmailFormatOf::validate_email_format("invalid@") # => ["does not appear to be a valid e-mail address"]
+ValidatesEmailFormatOf::validate_email_format("invalid@") # => ["does not appear to be a valid email address"]
 ```
 
 ## Options
 
 | Option | Type | Description |
 | --- | --- | --- |
-| `:message` | String | A custom error message when the email format is invalid (default is: "does not appear to be a valid e-mail address") |
+| `:message` | String | A custom error message when the email format is invalid (default is: "does not appear to be a valid email address") |
 | `:check_mx` | Boolean | Check domain for a valid MX record (default is false) |
 | `:check_mx_timeout` | Integer | Timeout in seconds for checking MX records before a `ResolvTimeout` is raised (default is 3). |
 | `:mx_message` | String | A custom error message when the domain does not match a valid MX record (default is: "is not routable").  Ignored unless :check_mx option is true. |

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2,7 +2,7 @@ de:
   activemodel: &errors
     errors:
       messages:
-        invalid_email_address: 'ist offensichtlich keine gültige E-Mail-Adresse'
+        invalid_email_address: 'ist offensichtlich keine gültige EMail-Adresse'
         email_address_not_routable: 'kann nicht erreicht werden'
   activerecord:
     <<: *errors

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@ en:
   activemodel: &errors
     errors:
       messages:
-        invalid_email_address: 'does not appear to be a valid e-mail address'
+        invalid_email_address: 'does not appear to be a valid email address'
         email_address_not_routable: 'is not routable'
   activerecord:
     <<: *errors

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -2,7 +2,7 @@ it:
   activemodel: &errors
     errors:
       messages:
-        invalid_email_address: 'non sembra un indirizzo e-mail valido'
+        invalid_email_address: 'non sembra un indirizzo email valido'
         email_address_not_routable: 'dominio non raggiungibile'
   activerecord:
     <<: *errors

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -2,7 +2,7 @@ pl:
   activemodel: &errors
     errors:
       messages:
-        invalid_email_address: 'nieprawidłowy adres e-mail'
+        invalid_email_address: 'nieprawidłowy adres email'
         email_address_not_routable: 'jest nieosiągalny'
   activerecord:
     <<: *errors

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -2,7 +2,7 @@ pt-BR:
   activemodel: &errors
     errors:
       messages:
-        invalid_email_address: 'não parece ser um endereço de e-mail válido'
+        invalid_email_address: 'não parece ser um endereço de email válido'
         email_address_not_routable: 'não é acessível'
   activerecord:
     <<: *errors

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -2,7 +2,7 @@ pt:
   activemodel: &errors
     errors:
       messages:
-        invalid_email_address: 'não parece ser um endereço de e-mail válido'
+        invalid_email_address: 'não parece ser um endereço de email válido'
         email_address_not_routable: 'não é acessível'
   activerecord:
     <<: *errors

--- a/spec/validates_email_format_of_spec.rb
+++ b/spec/validates_email_format_of_spec.rb
@@ -137,7 +137,7 @@ describe ValidatesEmailFormatOf do
       "(unbalancedcomment@example.com"
     ].each do |address|
       describe address do
-        it { should have_errors_on_email.because("does not appear to be a valid e-mail address") }
+        it { should have_errors_on_email.because("does not appear to be a valid email address") }
       end
     end
 
@@ -147,7 +147,7 @@ describe ValidatesEmailFormatOf do
           it { should_not have_errors_on_email }
         end
         describe "#{"a" * (limit + 1)}@example.com" do
-          it { should have_errors_on_email.because("does not appear to be a valid e-mail address") }
+          it { should have_errors_on_email.because("does not appear to be a valid email address") }
         end
       end
       describe "when using default" do
@@ -164,7 +164,7 @@ describe ValidatesEmailFormatOf do
           it { should_not have_errors_on_email }
         end
         describe "user@#{"a." * (limit / 2 + 1)}com" do
-          it { should have_errors_on_email.because("does not appear to be a valid e-mail address") }
+          it { should have_errors_on_email.because("does not appear to be a valid email address") }
         end
       end
       describe "when using default" do
@@ -270,7 +270,7 @@ describe ValidatesEmailFormatOf do
         it { should_not have_errors_on_email }
       end
       describe "valid@example.com" do
-        it { should have_errors_on_email.because("does not appear to be a valid e-mail address") }
+        it { should have_errors_on_email.because("does not appear to be a valid email address") }
       end
     end
 
@@ -281,7 +281,7 @@ describe ValidatesEmailFormatOf do
       describe "present locale" do
         let(:locale) { :pl }
         describe "invalid@exmaple." do
-          it { should have_errors_on_email.because("nieprawidłowy adres e-mail") }
+          it { should have_errors_on_email.because("nieprawidłowy adres email") }
         end
       end
     end

--- a/validates_email_format_of.gemspec
+++ b/validates_email_format_of.gemspec
@@ -4,7 +4,7 @@ require "validates_email_format_of/version"
 Gem::Specification.new do |s|
   s.name = "validates_email_format_of"
   s.version = ValidatesEmailFormatOf::VERSION
-  s.summary = "Validate e-mail addresses against RFC 2822 and RFC 3696."
+  s.summary = "Validate email addresses against RFC 2822 and RFC 3696."
   s.description = s.summary
   s.authors = ["Alex Dunae", "Isaac Betesh"]
   s.email = ["code@dunae.ca", "iybetesh@gmail.com"]


### PR DESCRIPTION
The conventional spelling of "email" does not include a hyphen. A hyphen
is acceptable, just less conventional.

Sources:

Merriam-Webster dictionary lists it as the default spelling:
https://www.merriam-webster.com/dictionary/email

Stanford Professor Donald Knuth on email spelling:
https://www-cs-faculty.stanford.edu/~knuth/email.html

RFC 5322 uses the spelling "email".