### PR TITLE
Fix a couple of typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Ruby gem to validate email addresses against RFC 2822 and RFC 5322.
 
 This gem is the O.G. email validation gem for Rails.  It was started back in 2006.
 
-Why use this validator?  Instead of trying to validate email addresses with one giant regular expression, this library parses addresses character by character.  This lets us handle weird cases likes [nested comments](https://www.rfc-editor.org/rfc/rfc5322#appendix-A.5).  Gross but technically allowed.
+Why use this validator?  Instead of trying to validate email addresses with one giant regular expression, this library parses addresses character by character.  This lets us handle weird cases like [nested comments](https://www.rfc-editor.org/rfc/rfc5322#appendix-A.5).  Gross but technically allowed.
 
 In reality, most email validating scripts will get you where you need to go.  This library just aims to go all the way.
 
@@ -42,7 +42,7 @@ describe Person do
 end
 ```
 
-### Useage without Rails
+### Usage without Rails
 
 ```ruby
 # Optional, if you want error messages to be in your language


### PR DESCRIPTION
Plus there's an "addres(s)es" typo in the _About_:
><img width="303" alt="Screenshot 2023-09-12 at 9 04 13 AM" src="https://github.com/validates-email-format-of/validates_email_format_of/assets/3092522/3d3122e2-d522-4782-8d07-b38c7edbe3e3">
