### PR TITLE
Fix Turkish locale

### DIFF
--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,4 +1,4 @@
-en:
+tr:
   activemodel: &errors
     errors:
       messages:


### PR DESCRIPTION
I mistakenly used `en:` key instead of `tr:` in the YAML file (oops!).