### PR TITLE
Split domain parts before punycode conversion

### DIFF
--- a/lib/validates_email_format_of.rb
+++ b/lib/validates_email_format_of.rb
@@ -269,8 +269,8 @@ module ValidatesEmailFormatOf
   end
 
   def self.validate_domain_part_syntax(domain, idn: true)
-    domain = SimpleIDN.to_ascii(domain) if idn
     parts = domain.downcase.split(".", -1)
+    parts.map! { |part| SimpleIDN.to_ascii(part) } if idn
 
     return false if parts.length <= 1 # Only one domain part
 

--- a/spec/validates_email_format_of_spec.rb
+++ b/spec/validates_email_format_of_spec.rb
@@ -140,7 +140,8 @@ describe ValidatesEmailFormatOf do
       "\nnewline@example.com",
       " spacesbefore@example.com",
       "spacesafter@example.com ",
-      "(unbalancedcomment@example.com"
+      "(unbalancedcomment@example.com",
+      "help@.example.co.uk" # TLD can not start with a period
     ].each do |address|
       describe address do
         it { should have_errors_on_email.because("does not appear to be a valid email address") }
@@ -203,7 +204,8 @@ describe ValidatesEmailFormatOf do
 
     describe "when idn support is enabled" do
       before(:each) do
-        allow(SimpleIDN).to receive(:to_ascii).once.with("exämple.com").and_return("xn--exmple-cua.com")
+        expect(SimpleIDN).to receive(:to_ascii).with("exämple").and_return("xn--exmple-cua")
+        expect(SimpleIDN).to receive(:to_ascii).with("com").and_return("com")
       end
       let(:options) { {idn: true} }
       describe "test@exämple.com" do


### PR DESCRIPTION
SimpleIDN.to_ascii swallows the initial period, turning ".example.com" into "example.com"

Fixes https://github.com/validates-email-format-of/validates_email_format_of/issues/109