### PR TITLE
Fix German locale

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2,7 +2,7 @@ de:
   activemodel: &errors
     errors:
       messages:
-        invalid_email_address: 'ist offensichtlich keine gültige EMail-Adresse'
+        invalid_email_address: 'ist anscheinend keine gültige E-Mail-Adresse'
         email_address_not_routable: 'kann nicht erreicht werden'
   activerecord:
     <<: *errors


### PR DESCRIPTION
Just a small correction for the German locale:

- Use 'E-Mail' instead of 'EMail' (one could also use 'Email', but it is less common, see https://www.duden.de/rechtschreibung/E_Mail)
- Use 'anscheinend' instead of 'offensichtlich', because latter should only be used if absolutely certain (as in 'appears to be' vs. 'obviously')