### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/validates_email_forma…

### DIFF
--- a/validates_email_format_of.gemspec
+++ b/validates_email_format_of.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "standard"
   s.add_development_dependency "appraisal"
+
+  s.metadata["changelog_uri"] = s.homepage + "/blob/master/CHANGELOG.md"
 end


### PR DESCRIPTION
…t_of

By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/validates_email_format_of which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/